### PR TITLE
Update deno-http-base Deno Docker image to use hayd/deno

### DIFF
--- a/deno-http-base/Dockerfile
+++ b/deno-http-base/Dockerfile
@@ -1,6 +1,6 @@
-ARG DENO_VERSION=1.1.0
+ARG DENO_VERSION=1.10.1
 FROM openfaas/of-watchdog:0.7.7 as watchdog
-FROM austinrivas/deno-alpine:${DENO_VERSION}
+FROM hayd/deno:alpine-${DENO_VERSION}
 
 WORKDIR /root/
 


### PR DESCRIPTION
This change updates the `DENO_VERSION` build arg to the latest release of Deno.

Additionally, this change swaps the use of `austinrivas/deno-alpine` with the more supported
`hayd/deno:alpine` Docker image.